### PR TITLE
Add `row` and `column` with queryable children positions

### DIFF
--- a/examples/scroll_to_item.rs
+++ b/examples/scroll_to_item.rs
@@ -1,0 +1,137 @@
+use std::sync::LazyLock;
+
+use iced::widget::{button, center, column, container, pop, scrollable, text};
+use iced::{Center, Element, Fill, Length, Task};
+use sweeten::operation::position;
+use sweeten::widget::row;
+
+fn main() -> iced::Result {
+    iced::application(
+        "sweetened iced • lazy loading example",
+        App::update,
+        App::view,
+    )
+    .window_size((800.0, 350.0))
+    .centered()
+    .run()
+}
+
+#[derive(Default)]
+struct App;
+
+#[derive(Clone, Debug)]
+enum Message {
+    JumpTo(usize),
+    ItemVisible(usize),
+}
+
+const LANGUAGES: &[&str] = &[
+    "C#",
+    "C++",
+    "Clojure",
+    "Dart",
+    "Elixir",
+    "Erlang",
+    "F#",
+    "Go",
+    "Haskell",
+    "Java",
+    "JavaScript",
+    "Kotlin",
+    "OCaml",
+    "PHP",
+    "Python",
+    "Ruby",
+    "Rust",
+    "Scala",
+    "Swift",
+    "TypeScript",
+];
+
+const SCROLLABLE: LazyLock<scrollable::Id> =
+    LazyLock::new(|| scrollable::Id::new("my_scrollable"));
+
+const POSITION_TRACKER: LazyLock<position::Id> =
+    LazyLock::new(|| position::Id::new("languages_row"));
+
+impl App {
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::JumpTo(idx) => {
+                position::find_position(POSITION_TRACKER.clone(), idx).and_then(
+                    move |bounds| {
+                        println!("Jump to {} at {:?}", idx, bounds.x);
+                        scrollable::scroll_to(
+                            SCROLLABLE.clone(),
+                            scrollable::AbsoluteOffset {
+                                x: bounds.x,
+                                y: 0.0,
+                            },
+                        )
+                    },
+                )
+            }
+            Message::ItemVisible(idx) => {
+                println!("Item {} is now visible", idx);
+                Task::none()
+            }
+        }
+    }
+
+    fn view(&self) -> Element<Message> {
+        let nav_buttons = column![
+            text("Click on a # to jump to that item")
+                .width(Fill)
+                .center(),
+            scrollable(
+                row((0..LANGUAGES.len()).map(|idx| {
+                    button(text(idx).center())
+                        .on_press(Message::JumpTo(idx))
+                        .width(Length::Fixed(40.0))
+                        .into()
+                }))
+                .spacing(5.0)
+                .padding(10),
+            )
+            .direction(scrollable::Direction::Horizontal(
+                scrollable::Scrollbar::default().width(0).scroller_width(0),
+            ))
+            .width(Fill)
+        ]
+        .width(Fill);
+
+        let languages_list = scrollable(
+            row(LANGUAGES.iter().enumerate().map(|(idx, &lang)| {
+                let item =
+                    container(text(lang).center().width(Fill).height(Fill))
+                        .width(200.0)
+                        .height(200.0)
+                        .style(container::rounded_box);
+
+                pop(container(item).align_y(Center))
+                    .on_show(Message::ItemVisible(idx))
+                    .anticipate(100.0)
+                    .into()
+            }))
+            .id(POSITION_TRACKER.clone())
+            .spacing(10)
+            .align_y(Center),
+        )
+        .direction(scrollable::Direction::Horizontal(
+            scrollable::Scrollbar::default(),
+        ))
+        .id(SCROLLABLE.clone())
+        .spacing(10)
+        .width(Fill);
+
+        center(
+            column![nav_buttons, languages_list,]
+                .width(Fill)
+                .height(Fill)
+                .align_x(Center)
+                .spacing(20),
+        )
+        .padding(20)
+        .into()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod operation;
 pub mod widget;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,0 +1,1 @@
+pub mod position;

--- a/src/operation/position.rs
+++ b/src/operation/position.rs
@@ -1,0 +1,94 @@
+use iced::advanced::widget::operation::{Operation, Outcome};
+use iced::advanced::widget::{operate, Id};
+use iced::{Rectangle, Task};
+use std::any::Any;
+
+/// The internal state for tracking widget positions.
+pub trait Position {
+    /// Store the position of a child widget by index.
+    fn set(&mut self, index: usize, bounds: Rectangle);
+
+    /// Get the position of a child widget by index.
+    fn get(&self, index: usize) -> Option<Rectangle>;
+
+    /// Clear all stored positions.
+    fn clear(&mut self);
+}
+
+// A concrete wrapper type that can be used for downcasting
+pub struct PositionState {
+    position: Box<dyn Position>,
+}
+
+impl PositionState {
+    pub fn new<T: Position + 'static>(position: T) -> Self {
+        Self {
+            position: Box::new(position),
+        }
+    }
+}
+
+impl PositionState {
+    pub fn as_position(&self) -> &dyn Position {
+        &*self.position
+    }
+
+    pub fn as_position_mut(&mut self) -> &mut dyn Position {
+        &mut *self.position
+    }
+}
+
+/// Query to find the position of a specific child by index
+pub struct Query {
+    target_index: usize,
+    found_bounds: Option<Rectangle>,
+}
+
+impl Query {
+    pub fn new(index: usize) -> Self {
+        Self {
+            target_index: index,
+            found_bounds: None,
+        }
+    }
+}
+
+impl Operation<Option<Rectangle>> for Query {
+    fn container(
+        &mut self,
+        _id: Option<&Id>,
+        _bounds: Rectangle,
+        operate_on_children: &mut dyn FnMut(
+            &mut dyn Operation<Option<Rectangle>>,
+        ),
+    ) {
+        // If we haven't found our target yet, keep searching children
+        if self.found_bounds.is_none() {
+            operate_on_children(self);
+        }
+    }
+
+    fn custom(
+        &mut self,
+        _id: Option<&Id>,
+        _bounds: Rectangle,
+        state: &mut dyn Any,
+    ) {
+        if self.found_bounds.is_none() {
+            if let Some(position_state) = state.downcast_mut::<PositionState>()
+            {
+                self.found_bounds =
+                    position_state.as_position().get(self.target_index);
+            }
+        }
+    }
+
+    fn finish(&self) -> Outcome<Option<Rectangle>> {
+        Outcome::Some(self.found_bounds)
+    }
+}
+
+/// Create a [`Task`](iced::Task) to find the position of a specific child by index
+pub fn find_position(index: usize) -> Task<Option<Rectangle>> {
+    operate(Query::new(index))
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,17 +1,18 @@
-use iced::advanced::text;
+use iced::advanced::{renderer, text};
 use iced::Element;
 use std::borrow::Borrow;
 
 pub mod mouse_area;
 pub mod overlay;
 pub mod pick_list;
+pub mod row;
 
 /// A container intercepting mouse events.
 pub fn mouse_area<'a, Message, Theme, Renderer>(
     widget: impl Into<Element<'a, Message, Theme, Renderer>>,
 ) -> mouse_area::MouseArea<'a, Message, Theme, Renderer>
 where
-    Renderer: iced::advanced::renderer::Renderer,
+    Renderer: renderer::Renderer,
 {
     mouse_area::MouseArea::new(widget)
 }
@@ -33,4 +34,24 @@ where
     Renderer: text::Renderer,
 {
     pick_list::PickList::new(options, disabled, selected, on_selected)
+}
+
+#[macro_export]
+macro_rules! row {
+    () => (
+        $crate::widget::Row::new()
+    );
+    ($($x:expr),+ $(,)?) => (
+        $crate::widget::Row::with_children([$(iced::Element::from($x)),+])
+    );
+}
+
+pub fn row<'a, Message, Theme, Renderer>(
+    children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+) -> row::Row<'a, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Theme: 'a,
+{
+    row::Row::with_children(children)
 }

--- a/src/widget/row.rs
+++ b/src/widget/row.rs
@@ -1,0 +1,633 @@
+//! Distribute content horizontally.
+// This widget is a modification of the original `Row` widget from [`iced`]
+//
+// [`iced`]: https://github.com/iced-rs/iced
+//
+// Copyright 2019 Héctor Ramón, Iced contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::collections::HashMap;
+
+use iced::advanced::layout::{self, Layout};
+use iced::advanced::widget::{tree, Operation, Tree, Widget};
+use iced::advanced::{overlay, renderer, Clipboard, Shell};
+use iced::alignment::{Alignment, Vertical};
+use iced::{
+    mouse, Element, Event, Length, Padding, Pixels, Rectangle, Size, Vector,
+};
+
+use crate::operation::position;
+
+/// A container that distributes its contents horizontally.
+///
+/// # Example
+/// ```no_run
+/// # mod iced { pub mod widget { pub use iced_widget::*; } }
+/// # pub type State = ();
+/// # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
+/// use iced::widget::{button, row};
+///
+/// #[derive(Debug, Clone)]
+/// enum Message {
+///     // ...
+/// }
+///
+/// fn view(state: &State) -> Element<'_, Message> {
+///     row![
+///         "I am to the left!",
+///         button("I am in the middle!"),
+///         "I am to the right!",
+///     ].into()
+/// }
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct Row<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer> {
+    spacing: f32,
+    padding: Padding,
+    width: Length,
+    height: Length,
+    align: Alignment,
+    clip: bool,
+    children: Vec<Element<'a, Message, Theme, Renderer>>,
+}
+
+impl<'a, Message, Theme, Renderer> Row<'a, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    /// Creates an empty [`Row`].
+    pub fn new() -> Self {
+        Self::from_vec(Vec::new())
+    }
+
+    /// Creates a [`Row`] with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::from_vec(Vec::with_capacity(capacity))
+    }
+
+    /// Creates a [`Row`] with the given elements.
+    pub fn with_children(
+        children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        let iterator = children.into_iter();
+
+        Self::with_capacity(iterator.size_hint().0).extend(iterator)
+    }
+
+    /// Creates a [`Row`] from an already allocated [`Vec`].
+    ///
+    /// Keep in mind that the [`Row`] will not inspect the [`Vec`], which means
+    /// it won't automatically adapt to the sizing strategy of its contents.
+    ///
+    /// If any of the children have a [`Length::Fill`] strategy, you will need to
+    /// call [`Row::width`] or [`Row::height`] accordingly.
+    pub fn from_vec(
+        children: Vec<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        Self {
+            spacing: 0.0,
+            padding: Padding::ZERO,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            align: Alignment::Start,
+            clip: false,
+            children,
+        }
+    }
+
+    /// Sets the horizontal spacing _between_ elements.
+    ///
+    /// Custom margins per element do not exist in iced. You should use this
+    /// method instead! While less flexible, it helps you keep spacing between
+    /// elements consistent.
+    pub fn spacing(mut self, amount: impl Into<Pixels>) -> Self {
+        self.spacing = amount.into().0;
+        self
+    }
+
+    /// Sets the [`Padding`] of the [`Row`].
+    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
+        self.padding = padding.into();
+        self
+    }
+
+    /// Sets the width of the [`Row`].
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Sets the height of the [`Row`].
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
+        self
+    }
+
+    /// Sets the vertical alignment of the contents of the [`Row`] .
+    pub fn align_y(mut self, align: impl Into<Vertical>) -> Self {
+        self.align = Alignment::from(align.into());
+        self
+    }
+
+    /// Sets whether the contents of the [`Row`] should be clipped on
+    /// overflow.
+    pub fn clip(mut self, clip: bool) -> Self {
+        self.clip = clip;
+        self
+    }
+
+    /// Adds an [`Element`] to the [`Row`].
+    pub fn push(
+        mut self,
+        child: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        let child = child.into();
+        let child_size = child.as_widget().size_hint();
+
+        self.width = self.width.enclose(child_size.width);
+        self.height = self.height.enclose(child_size.height);
+
+        self.children.push(child);
+        self
+    }
+
+    /// Adds an element to the [`Row`], if `Some`.
+    pub fn push_maybe(
+        self,
+        child: Option<impl Into<Element<'a, Message, Theme, Renderer>>>,
+    ) -> Self {
+        if let Some(child) = child {
+            self.push(child)
+        } else {
+            self
+        }
+    }
+
+    /// Extends the [`Row`] with the given children.
+    pub fn extend(
+        self,
+        children: impl IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        children.into_iter().fold(self, Self::push)
+    }
+
+    /// Turns the [`Row`] into a [`Wrapping`] row.
+    ///
+    /// The original alignment of the [`Row`] is preserved per row wrapped.
+    pub fn wrap(self) -> Wrapping<'a, Message, Theme, Renderer> {
+        Wrapping { row: self }
+    }
+}
+
+impl<Message, Renderer> Default for Row<'_, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'a, Message, Theme, Renderer: renderer::Renderer>
+    FromIterator<Element<'a, Message, Theme, Renderer>>
+    for Row<'a, Message, Theme, Renderer>
+{
+    fn from_iter<
+        T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+    >(
+        iter: T,
+    ) -> Self {
+        Self::with_children(iter)
+    }
+}
+
+struct State {
+    positions: position::PositionState,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            positions: position::PositionState::new(PositionMap::default()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct PositionMap {
+    map: HashMap<usize, Rectangle>,
+}
+
+impl position::Position for PositionMap {
+    fn set(&mut self, id: usize, bounds: Rectangle) {
+        self.map.insert(id, bounds);
+    }
+
+    fn get(&self, id: usize) -> Option<Rectangle> {
+        self.map.get(&id).copied()
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+    }
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Row<'_, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn children(&self) -> Vec<Tree> {
+        self.children.iter().map(Tree::new).collect()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(&self.children);
+    }
+
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::default())
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let state = tree.state.downcast_mut::<State>();
+        state.positions.as_position_mut().clear();
+
+        let node = layout::flex::resolve(
+            layout::flex::Axis::Horizontal,
+            renderer,
+            limits,
+            self.width,
+            self.height,
+            self.padding,
+            self.spacing,
+            self.align,
+            &self.children,
+            &mut tree.children,
+        );
+
+        for (index, layout) in node.children().iter().enumerate() {
+            state
+                .positions
+                .as_position_mut()
+                .set(index, layout.bounds());
+        }
+
+        node
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        let state = tree.state.downcast_mut::<State>();
+
+        operation.custom(None, layout.bounds(), state);
+
+        operation.container(None, layout.bounds(), &mut |operation| {
+            self.children
+                .iter()
+                .zip(&mut tree.children)
+                .zip(layout.children())
+                .for_each(|((child, state), layout)| {
+                    child
+                        .as_widget()
+                        .operate(state, layout, renderer, operation);
+                });
+        });
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        for ((child, state), layout) in self
+            .children
+            .iter_mut()
+            .zip(&mut tree.children)
+            .zip(layout.children())
+        {
+            child.as_widget_mut().update(
+                state,
+                event.clone(),
+                layout,
+                cursor,
+                renderer,
+                clipboard,
+                shell,
+                viewport,
+            );
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.children
+            .iter()
+            .zip(&tree.children)
+            .zip(layout.children())
+            .map(|((child, state), layout)| {
+                child.as_widget().mouse_interaction(
+                    state, layout, cursor, viewport, renderer,
+                )
+            })
+            .max()
+            .unwrap_or_default()
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        if let Some(clipped_viewport) = layout.bounds().intersection(viewport) {
+            let viewport = if self.clip {
+                &clipped_viewport
+            } else {
+                viewport
+            };
+
+            for ((child, state), layout) in self
+                .children
+                .iter()
+                .zip(&tree.children)
+                .zip(layout.children())
+                .filter(|(_, layout)| layout.bounds().intersects(viewport))
+            {
+                child.as_widget().draw(
+                    state, renderer, theme, style, layout, cursor, viewport,
+                );
+            }
+        }
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        overlay::from_children(
+            &mut self.children,
+            tree,
+            layout,
+            renderer,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Row<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: renderer::Renderer + 'a,
+{
+    fn from(row: Row<'a, Message, Theme, Renderer>) -> Self {
+        Self::new(row)
+    }
+}
+
+/// A [`Row`] that wraps its contents.
+///
+/// Create a [`Row`] first, and then call [`Row::wrap`] to
+/// obtain a [`Row`] that wraps its contents.
+///
+/// The original alignment of the [`Row`] is preserved per row wrapped.
+#[allow(missing_debug_implementations)]
+pub struct Wrapping<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+{
+    row: Row<'a, Message, Theme, Renderer>,
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Wrapping<'_, Message, Theme, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn children(&self) -> Vec<Tree> {
+        self.row.children()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        self.row.diff(tree);
+    }
+
+    fn size(&self) -> Size<Length> {
+        self.row.size()
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let limits = limits
+            .width(self.row.width)
+            .height(self.row.height)
+            .shrink(self.row.padding);
+
+        let spacing = self.row.spacing;
+        let max_width = limits.max().width;
+
+        let mut children: Vec<layout::Node> = Vec::new();
+        let mut intrinsic_size = Size::ZERO;
+        let mut row_start = 0;
+        let mut row_height = 0.0;
+        let mut x = 0.0;
+        let mut y = 0.0;
+
+        let align_factor = match self.row.align {
+            Alignment::Start => 0.0,
+            Alignment::Center => 2.0,
+            Alignment::End => 1.0,
+        };
+
+        let align = |row_start: std::ops::Range<usize>,
+                     row_height: f32,
+                     children: &mut Vec<layout::Node>| {
+            if align_factor != 0.0 {
+                for node in &mut children[row_start] {
+                    let height = node.size().height;
+
+                    node.translate_mut(Vector::new(
+                        0.0,
+                        (row_height - height) / align_factor,
+                    ));
+                }
+            }
+        };
+
+        for (i, child) in self.row.children.iter().enumerate() {
+            let node = child.as_widget().layout(
+                &mut tree.children[i],
+                renderer,
+                &limits,
+            );
+
+            let child_size = node.size();
+
+            if x != 0.0 && x + child_size.width > max_width {
+                intrinsic_size.width = intrinsic_size.width.max(x - spacing);
+
+                align(row_start..i, row_height, &mut children);
+
+                y += row_height + spacing;
+                x = 0.0;
+                row_start = i;
+                row_height = 0.0;
+            }
+
+            row_height = row_height.max(child_size.height);
+
+            children.push(node.move_to((
+                x + self.row.padding.left,
+                y + self.row.padding.top,
+            )));
+
+            x += child_size.width + spacing;
+        }
+
+        if x != 0.0 {
+            intrinsic_size.width = intrinsic_size.width.max(x - spacing);
+        }
+
+        intrinsic_size.height = y + row_height;
+        align(row_start..children.len(), row_height, &mut children);
+
+        let size =
+            limits.resolve(self.row.width, self.row.height, intrinsic_size);
+
+        layout::Node::with_children(size.expand(self.row.padding), children)
+    }
+
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.row.operate(tree, layout, renderer, operation);
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.row.update(
+            tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.row
+            .mouse_interaction(tree, layout, cursor, viewport, renderer)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        self.row
+            .draw(tree, renderer, theme, style, layout, cursor, viewport);
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.row.overlay(tree, layout, renderer, translation)
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Wrapping<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: 'a,
+    Theme: 'a,
+    Renderer: renderer::Renderer + 'a,
+{
+    fn from(row: Wrapping<'a, Message, Theme, Renderer>) -> Self {
+        Self::new(row)
+    }
+}


### PR DESCRIPTION
Adds a `find_position` operation to a copy of the built-in `row` and `column` widgets from `iced` which allows the user to find the `Point` position of any children.

This can be used, for example, to scroll to a specific element in a `scrollable` wrapping such a `row` or `column`, as the example demonstrates.