### PR TITLE
feat: focusable button (iced 0.14) + docs/examples

### DIFF
--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,0 +1,183 @@
+//! Demonstrates the enhanced button widget with focus/blur messages.
+//!
+//! This example shows:
+//! - `on_focus(Message)` - emit a message when the button gains focus
+//! - `on_blur(Message)` - emit a message when the button loses focus
+//! - `on_press(Message)` - emit a message when clicked/activated
+//! - Tab / Shift+Tab navigation between focus target buttons
+//!
+//! Run with: `cargo run --example button`
+
+use iced::{
+    Element, Fill, Subscription, Task, keyboard,
+    widget::{Id, column, container, operation, text},
+};
+
+use sweeten::focusable_button;
+
+#[derive(Debug, Clone)]
+enum Message {
+    Focus(Target),
+    Blur(Target),
+    Incremented,
+    Decremented,
+    Reset,
+    TabPressed { shift: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Target {
+    IncrementButton,
+    DecrementButton,
+    ResetButton,
+}
+
+struct App {
+    focused: bool,
+    count: i32,
+    last_event: &'static str,
+    focused_target: Target,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        App {
+            focused: false,
+            count: 0,
+            last_event: "none",
+            focused_target: Target::IncrementButton,
+        }
+    }
+}
+
+impl App {
+    fn view(&self) -> Element<'_, Message> {
+        let label = if self.focused {
+            "Focused"
+        } else {
+            "Not focused"
+        };
+
+        let reset = focusable_button(text("Reset"))
+            .id(reset_id())
+            .on_press(Message::Reset)
+            .on_focus(Message::Focus(Target::ResetButton))
+            .on_blur(Message::Blur(Target::ResetButton));
+
+        let increment = focusable_button(text("+ 1"))
+            .id(inc_id())
+            .on_press(Message::Incremented)
+            .on_focus(Message::Focus(Target::IncrementButton))
+            .on_blur(Message::Blur(Target::IncrementButton));
+
+        let decrement = focusable_button(text("- 1"))
+            .id(dec_id())
+            .on_press(Message::Decremented)
+            .on_focus(Message::Focus(Target::DecrementButton))
+            .on_blur(Message::Blur(Target::DecrementButton));
+
+        container(
+            column![
+                text(format!("Focus state: {label}")),
+                text(format!("Press count: {}", self.count)),
+                text(format!("Last event: {}", self.last_event)),
+                increment,
+                decrement,
+                reset,
+            ]
+            .spacing(12),
+        )
+        .center(Fill)
+        .into()
+    }
+
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::TabPressed { shift } => {
+                self.focused_target = next_target(self.focused_target, shift);
+                self.last_event = "tabbed";
+
+                return operation::focus(target_id(self.focused_target));
+            }
+            Message::Focus(t) => {
+                self.focused_target = t;
+                self.last_event = "focused";
+            }
+            Message::Blur(_t) => {
+                self.last_event = "blurred";
+            }
+            Message::Incremented => {
+                self.count += 1;
+                self.last_event = "pressed";
+            }
+            Message::Decremented => {
+                self.count -= 1;
+                self.last_event = "pressed";
+            }
+            Message::Reset => {
+                self.count = 0;
+                self.last_event = "reset";
+            }
+        }
+        Task::none()
+    }
+}
+
+fn main() -> iced::Result {
+    iced::application(App::default, update, view)
+        .title("Sweeten - focusable button")
+        .subscription(subscription)
+        .centered()
+        .run()
+}
+
+fn update(app: &mut App, message: Message) -> iced::Task<Message> {
+    app.update(message)
+}
+
+fn view(app: &App) -> iced::Element<'_, Message> {
+    app.view()
+}
+
+fn subscription(_app: &App) -> Subscription<Message> {
+    keyboard::on_key_press(|key, modifiers| match key {
+        keyboard::Key::Named(keyboard::key::Named::Tab) => {
+            Some(Message::TabPressed {
+                shift: modifiers.shift(),
+            })
+        }
+        _ => None,
+    })
+}
+
+fn dec_id() -> Id {
+    Id::new("dec")
+}
+
+fn inc_id() -> Id {
+    Id::new("inc")
+}
+
+fn reset_id() -> Id {
+    Id::new("reset")
+}
+
+fn next_target(current: Target, shift: bool) -> Target {
+    match (current, shift) {
+        (Target::IncrementButton, false) => Target::DecrementButton,
+        (Target::DecrementButton, false) => Target::ResetButton,
+        (Target::ResetButton, false) => Target::IncrementButton,
+
+        (Target::IncrementButton, true) => Target::ResetButton,
+        (Target::DecrementButton, true) => Target::IncrementButton,
+        (Target::ResetButton, true) => Target::DecrementButton,
+    }
+}
+
+fn target_id(target: Target) -> Id {
+    match target {
+        Target::IncrementButton => inc_id(),
+        Target::DecrementButton => dec_id(),
+        Target::ResetButton => reset_id(),
+    }
+}

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -27,9 +27,9 @@ enum Message {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Target {
-    IncrementButton,
-    DecrementButton,
-    ResetButton,
+    Increment,
+    Decrement,
+    Reset,
 }
 
 struct App {
@@ -45,7 +45,7 @@ impl Default for App {
             focused: false,
             count: 0,
             last_event: "none",
-            focused_target: Target::IncrementButton,
+            focused_target: Target::Increment,
         }
     }
 }
@@ -61,20 +61,20 @@ impl App {
         let reset = focusable_button(text("Reset"))
             .id(reset_id())
             .on_press(Message::Reset)
-            .on_focus(Message::Focus(Target::ResetButton))
-            .on_blur(Message::Blur(Target::ResetButton));
+            .on_focus(Message::Focus(Target::Reset))
+            .on_blur(Message::Blur(Target::Reset));
 
         let increment = focusable_button(text("+ 1"))
             .id(inc_id())
             .on_press(Message::Incremented)
-            .on_focus(Message::Focus(Target::IncrementButton))
-            .on_blur(Message::Blur(Target::IncrementButton));
+            .on_focus(Message::Focus(Target::Increment))
+            .on_blur(Message::Blur(Target::Increment));
 
         let decrement = focusable_button(text("- 1"))
             .id(dec_id())
             .on_press(Message::Decremented)
-            .on_focus(Message::Focus(Target::DecrementButton))
-            .on_blur(Message::Blur(Target::DecrementButton));
+            .on_focus(Message::Focus(Target::Decrement))
+            .on_blur(Message::Blur(Target::Decrement));
 
         container(
             column![
@@ -164,20 +164,20 @@ fn reset_id() -> Id {
 
 fn next_target(current: Target, shift: bool) -> Target {
     match (current, shift) {
-        (Target::IncrementButton, false) => Target::DecrementButton,
-        (Target::DecrementButton, false) => Target::ResetButton,
-        (Target::ResetButton, false) => Target::IncrementButton,
+        (Target::Increment, false) => Target::Decrement,
+        (Target::Decrement, false) => Target::Reset,
+        (Target::Reset, false) => Target::Increment,
 
-        (Target::IncrementButton, true) => Target::ResetButton,
-        (Target::DecrementButton, true) => Target::IncrementButton,
-        (Target::ResetButton, true) => Target::DecrementButton,
+        (Target::Increment, true) => Target::Reset,
+        (Target::Decrement, true) => Target::Increment,
+        (Target::Reset, true) => Target::Decrement,
     }
 }
 
 fn target_id(target: Target) -> Id {
     match target {
-        Target::IncrementButton => inc_id(),
-        Target::DecrementButton => dec_id(),
-        Target::ResetButton => reset_id(),
+        Target::Increment => inc_id(),
+        Target::Decrement => dec_id(),
+        Target::Reset => reset_id(),
     }
 }

--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -14,7 +14,7 @@ use iced::widget::{
 };
 use iced::{Center, Element, Fill, Subscription, Task};
 
-use sweeten::text_input;
+use sweeten::focusable_text_input as text_input;
 
 fn main() -> iced::Result {
     iced::application(App::new, App::update, App::view)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -67,7 +67,7 @@ where
 /// [`iced`'s `text_input`]: https://docs.iced.rs/iced/widget/text_input/index.html
 /// [`on_focus`]: TextInput::on_focus
 /// [`on_blur`]: TextInput::on_blur
-pub fn text_input<'a, Message, Theme, Renderer>(
+pub fn focusable_text_input<'a, Message, Theme, Renderer>(
     placeholder: &str,
     value: &str,
 ) -> TextInput<'a, Message, Theme, Renderer>
@@ -116,4 +116,20 @@ where
     Renderer: core::Renderer,
 {
     MouseArea::new(widget)
+}
+
+/// Creates a new [`Button`] within the given context.
+///
+/// This is a sweetened version of [`iced`'s `Button`] with support for [`on_focus`]
+/// and [`on_blur`] messages, making it focusable.
+///
+/// [`iced`'s `Button`]: https://docs.iced.rs/iced/widget/button/struct.Button.html
+pub fn focusable_button<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> crate::widget::button::Button<'a, Message, Theme, Renderer>
+where
+    Renderer: core::Renderer,
+    Theme: crate::widget::button::Catalog,
+{
+    crate::widget::button::Button::new(content)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,13 +69,16 @@
 mod helpers;
 pub mod widget;
 
+pub use crate::helpers::focusable_button;
+pub use crate::helpers::focusable_text_input;
 pub use helpers::*;
 
 // Re-exports to mirror iced_widget structure (allows minimal diff for widgets)
 pub use iced_core as core;
 pub use iced_core::Theme;
 pub use iced_widget::Renderer;
-pub use iced_widget::{button, scrollable, text_editor};
+pub use iced_widget::button as iced_button;
+pub use iced_widget::{scrollable, text_editor};
 
 // Re-export widget modules at crate level (mirrors iced_widget's structure)
 pub use widget::overlay;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,15 @@
 //! [`on_focus`]: widget::text_input::TextInput::on_focus
 //! [`on_blur`]: widget::text_input::TextInput::on_blur
 
+/// Convenient imports for Sweeten's enhanced widgets.
+///
+/// Importing this prelude lets you use [`button(...)`] / [`text_input(...)`]
+/// without colliding with the crate's `widget::*` modules.
+pub mod prelude {
+    pub use crate::focusable_button as button;
+    pub use crate::focusable_text_input as text_input;
+}
+
 mod helpers;
 pub mod widget;
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -6,6 +6,7 @@
 //!
 //! [`iced`]: https://github.com/iced-rs/iced
 
+pub mod button;
 pub mod column;
 pub mod drag;
 pub mod mouse_area;
@@ -15,11 +16,14 @@ pub mod row;
 pub mod text_input;
 
 pub use column::Column;
+
+pub use button::Button;
 pub use mouse_area::MouseArea;
 pub use pick_list::PickList;
 pub use row::Row;
 pub use text_input::TextInput;
 
 // Re-export helper functions and macros (same pattern as iced_widget)
-pub use crate::helpers::*;
+pub use crate::helpers::focusable_button;
+pub use crate::helpers::focusable_text_input;
 pub use crate::{column, row};

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -1,0 +1,860 @@
+//! This widget is a modification of the original `Button` widget from [`iced`]
+//!
+//! [`iced`]: https://github.com/iced-rs/iced
+//!
+//! Copyright 2019 Héctor Ramón, Iced contributors
+//!
+//! Permission is hereby granted, free of charge, to any person obtaining a copy of
+//! this software and associated documentation files (the "Software"), to deal in
+//! the Software without restriction, including without limitation the rights to
+//! use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+//! the Software, and to permit persons to whom the Software is furnished to do so,
+//! subject to the following conditions:
+//!
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//!
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+//! FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+//! COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+//! IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//! CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use crate::core::Layout;
+use crate::core::border::{self, Border};
+use crate::core::event::Event;
+use crate::core::keyboard;
+use crate::core::layout;
+use crate::core::mouse;
+use crate::core::overlay;
+use crate::core::renderer;
+use crate::core::theme::palette;
+use crate::core::touch;
+use crate::core::widget::Id;
+use crate::core::widget::operation::{Focusable, Operation};
+use crate::core::widget::tree::{self, Tree};
+use crate::core::{
+    Background, Color, Element, Length, Padding, Rectangle, Size, Theme, Vector,
+};
+use crate::core::{Clipboard, Shell, Widget};
+pub use iced_widget::button::Style;
+
+/// A clickable button.
+///
+/// # Example
+/// ```no_run
+/// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
+/// # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
+/// #
+/// use iced::widget::{button, text};
+///
+/// #[derive(Debug, Clone)]
+/// enum Message {
+///     Pressed,
+/// }
+///
+/// fn view() -> Element<'static, Message> {
+///     button(text("Click me"))
+///         .on_press(Message::Pressed)
+///         .into()
+/// }
+///
+/// fn update(message: Message) {
+///     match Message {
+///         Message::Pressed => {
+///             // Handle button press
+///         }
+///     }
+/// }
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct Button<
+    'a,
+    Message,
+    Theme = crate::core::Theme,
+    Renderer = iced_widget::Renderer,
+> where
+    Renderer: crate::core::Renderer,
+    Theme: Catalog,
+{
+    content: Element<'a, Message, Theme, Renderer>,
+    on_press: Option<OnPress<'a, Message>>,
+    on_focus: Option<Message>,
+    on_blur: Option<Message>,
+    id: Option<Id>,
+    width: Length,
+    height: Length,
+    padding: Padding,
+    clip: bool,
+    class: Theme::Class<'a>,
+}
+
+enum OnPress<'a, Message> {
+    Direct(Message),
+    Closure(Box<dyn Fn() -> Message + 'a>),
+}
+
+impl<'a, Message: Clone> OnPress<'a, Message> {
+    fn get(&self) -> Message {
+        match self {
+            OnPress::Direct(message) => message.clone(),
+            OnPress::Closure(f) => f(),
+        }
+    }
+}
+
+impl<'a, Message, Theme, Renderer> Button<'a, Message, Theme, Renderer>
+where
+    Renderer: crate::core::Renderer,
+    Theme: Catalog,
+{
+    /// Creates a new [`Button`] with the given content.
+    pub fn new(
+        content: impl Into<Element<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        let content = content.into();
+        let size = content.as_widget().size_hint();
+
+        Button {
+            content,
+            on_press: None,
+            on_focus: None,
+            on_blur: None,
+            id: Some(Id::unique()),
+            width: size.width.fluid(),
+            height: size.height.fluid(),
+            padding: DEFAULT_PADDING,
+            clip: false,
+            class: Theme::default(),
+        }
+    }
+
+    /// Sets the width of the [`Button`].
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Sets the [`Id`] of the [`Button`].
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Sets the height of the [`Button`].
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
+        self
+    }
+
+    /// Sets the [`Padding`] of the [`Button`].
+    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
+        self.padding = padding.into();
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Button`] is pressed.
+    ///
+    /// Unless `on_press` is called, the [`Button`] will be disabled.
+    pub fn on_press(mut self, on_press: Message) -> Self {
+        self.on_press = Some(OnPress::Direct(on_press));
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Button`] is pressed.
+    ///
+    /// This is analogous to [`Button::on_press`], but using a closure to produce
+    /// the message.
+    ///
+    /// This closure will only be called when the [`Button`] is actually pressed and,
+    /// therefore, this method is useful to reduce overhead if creating the resulting
+    /// message is slow.
+    pub fn on_press_with(
+        mut self,
+        on_press: impl Fn() -> Message + 'a,
+    ) -> Self {
+        self.on_press = Some(OnPress::Closure(Box::new(on_press)));
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Button`] is pressed,
+    /// if `Some`.
+    ///
+    /// If `None`, the [`Button`] will be disabled.
+    pub fn on_press_maybe(mut self, on_press: Option<Message>) -> Self {
+        self.on_press = on_press.map(OnPress::Direct);
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Button`] is focused.
+    pub fn on_focus(mut self, on_focus: Message) -> Self {
+        self.on_focus = Some(on_focus);
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Button`] is blurred.
+    pub fn on_blur(mut self, on_blur: Message) -> Self {
+        self.on_blur = Some(on_blur);
+        self
+    }
+
+    /// Sets whether the contents of the [`Button`] should be clipped on
+    /// overflow.
+    pub fn clip(mut self, clip: bool) -> Self {
+        self.clip = clip;
+        self
+    }
+
+    /// Sets the style of the [`Button`].
+    #[must_use]
+    pub fn style(mut self, style: impl Fn(&Theme, Status) -> Style + 'a) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        self.class = (Box::new(style) as StyleFn<'a, Theme>).into();
+        self
+    }
+
+    /// Sets the style class of the [`Button`].
+    #[must_use]
+    pub fn class(mut self, class: impl Into<Theme::Class<'a>>) -> Self {
+        self.class = class.into();
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct State {
+    is_focused: bool,
+    was_focused: bool,
+    status: Status,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            is_focused: false,
+            was_focused: false,
+            status: Status::Active,
+        }
+    }
+}
+
+impl Focusable for State {
+    fn is_focused(&self) -> bool {
+        self.is_focused
+    }
+
+    fn focus(&mut self) {
+        // Don't allow focus if disabled
+        if self.status != Status::Disabled {
+            self.is_focused = true;
+        }
+    }
+
+    fn unfocus(&mut self) {
+        self.is_focused = false;
+    }
+}
+
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for Button<'a, Message, Theme, Renderer>
+where
+    Message: 'a + Clone,
+    Renderer: 'a + crate::core::Renderer,
+    Theme: Catalog,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::default())
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_ref(&self.content));
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        layout::padded(
+            limits,
+            self.width,
+            self.height,
+            self.padding,
+            |limits| {
+                self.content.as_widget_mut().layout(
+                    &mut tree.children[0],
+                    renderer,
+                    limits,
+                )
+            },
+        )
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        let state = tree.state.downcast_mut::<State>();
+
+        // Sync disabled status so Focusable::focus() can check it
+        if self.on_press.is_none() {
+            state.status = Status::Disabled;
+        } else if state.status == Status::Disabled {
+            state.status = Status::Active;
+        }
+
+        operation.focusable(self.id.as_ref(), layout.bounds(), state);
+
+        self.content.as_widget_mut().operate(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+            operation,
+        );
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &iced_core::Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+
+        if shell.is_event_captured() {
+            return;
+        }
+        // Detect focus changes from operations (e.g., Tab key)
+        {
+            let state = tree.state.downcast_mut::<State>();
+            if state.is_focused != state.was_focused {
+                if state.is_focused {
+                    if let Some(on_focus) = &self.on_focus {
+                        shell.publish(on_focus.clone());
+                    }
+                } else if let Some(on_blur) = &self.on_blur {
+                    shell.publish(on_blur.clone());
+                }
+                state.was_focused = state.is_focused;
+            }
+        }
+
+        match event {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if self.on_press.is_some() {
+                    let bounds = layout.bounds();
+                    let state = tree.state.downcast_mut::<State>();
+
+                    if cursor.is_over(bounds) {
+                        state.status = Status::Pressed;
+
+                        if let Some(on_focus) = &self.on_focus {
+                            if !state.is_focused() {
+                                shell.publish(on_focus.clone());
+                            }
+                        }
+
+                        state.is_focused = true;
+                        state.was_focused = true;
+
+                        shell.capture_event();
+                    } else {
+                        if let Some(on_blur) = &self.on_blur {
+                            if state.is_focused() {
+                                shell.publish(on_blur.clone());
+                            }
+                        }
+
+                        state.is_focused = false;
+                        state.was_focused = false;
+                    }
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. }) => {
+                if let Some(on_press) = self.on_press.as_ref().map(OnPress::get)
+                {
+                    let state = tree.state.downcast_mut::<State>();
+
+                    if state.status == Status::Pressed {
+                        state.status = Status::Active;
+
+                        let bounds = layout.bounds();
+
+                        if cursor.is_over(bounds) {
+                            shell.publish(on_press);
+                        }
+
+                        shell.capture_event();
+                    }
+                }
+            }
+            Event::Touch(touch::Event::FingerLost { .. }) => {
+                let state = tree.state.downcast_mut::<State>();
+
+                state.status = Status::Active;
+            }
+            Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
+                if let Some(on_press) = self.on_press.as_ref() {
+                    let state = tree.state.downcast_mut::<State>();
+
+                    if state.is_focused()
+                        && matches!(
+                            key,
+                            keyboard::Key::Named(
+                                keyboard::key::Named::Enter
+                                    | keyboard::key::Named::Space
+                            )
+                        )
+                    {
+                        state.status = Status::Pressed;
+                        shell.publish(on_press.get());
+
+                        shell.capture_event();
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+        let content_layout = layout.children().next().unwrap();
+        let is_mouse_over = cursor.is_over(bounds);
+        let state = tree.state.downcast_ref::<State>();
+
+        let status = if self.on_press.is_none() {
+            Status::Disabled
+        } else if state.is_focused() {
+            Status::Focused {
+                is_hovered: is_mouse_over,
+            }
+        } else if is_mouse_over {
+            if state.status == Status::Pressed {
+                Status::Pressed
+            } else {
+                Status::Hovered
+            }
+        } else {
+            Status::Active
+        };
+
+        let style = theme.style(&self.class, status);
+
+        if style.background.is_some()
+            || style.border.width > 0.0
+            || style.shadow.color.a > 0.0
+        {
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds,
+                    border: style.border,
+                    shadow: style.shadow,
+                    snap: true,
+                },
+                style
+                    .background
+                    .unwrap_or(Background::Color(Color::TRANSPARENT)),
+            );
+        }
+
+        let viewport = if self.clip {
+            bounds.intersection(viewport).unwrap_or(*viewport)
+        } else {
+            *viewport
+        };
+
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            &renderer::Style {
+                text_color: style.text_color,
+            },
+            content_layout,
+            cursor,
+            &viewport,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &Renderer,
+    ) -> mouse::Interaction {
+        let is_mouse_over = cursor.is_over(layout.bounds());
+
+        if is_mouse_over && self.on_press.is_some() {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<Button<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+    Theme: Catalog + 'a,
+    Renderer: crate::core::Renderer + 'a,
+{
+    fn from(button: Button<'a, Message, Theme, Renderer>) -> Self {
+        Self::new(button)
+    }
+}
+
+/// The default [`Padding`] of a [`Button`].
+pub(crate) const DEFAULT_PADDING: Padding = Padding {
+    top: 5.0,
+    bottom: 5.0,
+    right: 10.0,
+    left: 10.0,
+};
+
+/// The possible status of a [`Button`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// The [`Button`] can be pressed.
+    Active,
+    /// The [`Button`] can be pressed and it is being hovered.
+    Hovered,
+    /// The [`Button`] is being pressed.
+    Pressed,
+    /// The [`Button`] is focused.
+    Focused {
+        /// Whether the [`Button`] is hovered, while focused.
+        is_hovered: bool,
+    },
+    /// The [`Button`] cannot be pressed.
+    Disabled,
+}
+
+/// A styling function for a [`Button`].
+///
+/// This is just a boxed closure: `Fn(&Theme, Status) -> Style`.
+pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme, Status) -> Style + 'a>;
+
+/// The theme catalog of a [`Button`].
+pub trait Catalog {
+    /// The item class of the [`Catalog`].
+    type Class<'a>;
+
+    /// The default class produced by the [`Catalog`].
+    fn default<'a>() -> Self::Class<'a>;
+
+    /// The [`Style`] of a class with the given status.
+    fn style(&self, class: &Self::Class<'_>, status: Status) -> Style;
+}
+
+impl Catalog for crate::Theme {
+    type Class<'a> = StyleFn<'a, Self>;
+
+    fn default<'a>() -> Self::Class<'a> {
+        Box::new(primary)
+    }
+
+    fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
+        class(self, status)
+    }
+}
+
+/// A primary button; denoting a main action.
+pub fn primary(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+    let base = styled(palette.primary.base);
+
+    match status {
+        Status::Active | Status::Pressed => base,
+        Status::Hovered => Style {
+            background: Some(Background::Color(palette.primary.strong.color)),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.primary.base.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(palette.primary.strong.color))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+/// A secondary button; denoting a complementary action.
+pub fn secondary(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+    let base = styled(palette.secondary.base);
+
+    match status {
+        Status::Active | Status::Pressed => base,
+        Status::Hovered => Style {
+            background: Some(Background::Color(palette.secondary.strong.color)),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.secondary.base.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(palette.secondary.strong.color))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+/// A success button; denoting a good outcome.
+pub fn success(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+    let base = styled(palette.success.base);
+
+    match status {
+        Status::Active | Status::Pressed => base,
+        Status::Hovered => Style {
+            background: Some(Background::Color(palette.success.strong.color)),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.success.base.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(palette.success.strong.color))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+/// A danger button; denoting a destructive action.
+pub fn danger(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+    let base = styled(palette.danger.base);
+
+    match status {
+        Status::Active | Status::Pressed => base,
+        Status::Hovered => Style {
+            background: Some(Background::Color(palette.danger.strong.color)),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.danger.base.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(palette.danger.strong.color))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+/// A text button; useful for links.
+pub fn text(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+
+    let base = Style {
+        text_color: palette.background.base.text,
+        ..Style::default()
+    };
+
+    match status {
+        Status::Active | Status::Pressed => base,
+        Status::Hovered => Style {
+            text_color: palette.background.base.text.scale_alpha(0.8),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.background.strong.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(
+                    palette.background.base.text.scale_alpha(0.8),
+                ))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+/// A button using background shades.
+pub fn background(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+    let base = styled(palette.background.base);
+
+    match status {
+        Status::Active => base,
+        Status::Pressed => Style {
+            background: Some(Background::Color(
+                palette.background.strong.color,
+            )),
+            ..base
+        },
+        Status::Hovered => Style {
+            background: Some(Background::Color(palette.background.weak.color)),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.background.base.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(palette.background.weak.color))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+/// A subtle button using weak background shades.
+pub fn subtle(theme: &Theme, status: Status) -> Style {
+    let palette = theme.extended_palette();
+    let base = styled(palette.background.weak);
+
+    match status {
+        Status::Active => base,
+        Status::Pressed => Style {
+            background: Some(Background::Color(
+                palette.background.strong.color,
+            )),
+            ..base
+        },
+        Status::Hovered => Style {
+            background: Some(Background::Color(palette.background.base.color)),
+            ..base
+        },
+        Status::Focused { is_hovered } => Style {
+            border: Border {
+                color: palette.background.base.text,
+                width: 2.0,
+                ..base.border
+            },
+            background: if is_hovered {
+                Some(Background::Color(palette.background.base.color))
+            } else {
+                base.background
+            },
+            ..base
+        },
+        Status::Disabled => disabled(base),
+    }
+}
+
+fn styled(pair: palette::Pair) -> Style {
+    Style {
+        background: Some(Background::Color(pair.color)),
+        text_color: pair.text,
+        border: border::rounded(2),
+        ..Style::default()
+    }
+}
+
+fn disabled(style: Style) -> Style {
+    Style {
+        background: style
+            .background
+            .map(|background| background.scale_alpha(0.5)),
+        text_color: style.text_color.scale_alpha(0.5),
+        ..style
+    }
+}

--- a/src/widget/pick_list.rs
+++ b/src/widget/pick_list.rs
@@ -71,7 +71,6 @@ use crate::core::{
     Padding, Pixels, Point, Rectangle, Shell, Size, Theme, Vector, Widget,
 };
 use crate::overlay::menu::{self, Menu};
-
 use std::borrow::Borrow;
 use std::f32;
 
@@ -199,7 +198,7 @@ where
             placeholder: None,
             selected,
             width: Length::Shrink,
-            padding: crate::button::DEFAULT_PADDING,
+            padding: crate::widget::button::DEFAULT_PADDING,
             text_size: None,
             text_line_height: text::LineHeight::default(),
             text_shaping: text::Shaping::default(),


### PR DESCRIPTION
1. Implements focusable button support in Sweeten (focus/blur messages).
2. Adds helper constructors [`focusable_button`] / [`focusable_text_input`] and missing docs.
3. Adds example demonstrating Tab / Shift+Tab focus traversal.

Helpers use `focusable_*` naming to avoid collision with existing modules. Prelude added to respect previous naming conventions.