### PR TITLE
feat(fit_text): add widget that scales font size to fit bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 [[package]]
 name = "iced"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -1124,7 +1124,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "futures",
  "iced_core",
@@ -1164,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1182,7 +1182,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1203,7 +1203,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "bytes",
  "iced_core",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -1250,7 +1250,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "iced_renderer",
  "log",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.15.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?branch=master#3fd974f54a294b2396f68e691703140c61e1e9e5"
+source = "git+https://github.com/iced-rs/iced.git?branch=master#ac1b2c7123ad82643482c0b3a4a776246c966697"
 dependencies = [
  "arboard",
  "iced_debug",
@@ -1271,6 +1271,7 @@ dependencies = [
  "iced_runtime",
  "log",
  "mundy",
+ "objc2 0.5.2",
  "rustc-hash 2.1.1",
  "thiserror 2.0.17",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -90,6 +90,28 @@ column(items.iter().map(|s| s.as_str().into()))
     .into()
 ```
 
+### `FitText`
+
+A text widget that auto-scales its font size to fit the bounds it is laid out
+into. Think CSS' `clamp(min, ideal, max)`, but the "ideal" is solved for
+instead of specified — `sweeten` binary-searches the size range and picks the
+largest font that still fits. Use it like:
+
+```rust
+use iced::Fill;
+use sweeten::widget::fit_text;
+
+fit_text("Big headline")
+    .max_size(120)
+    .min_size(16)
+    .width(Fill)
+    .height(Fill)
+    .center()
+```
+
+Both `min_size` and `max_size` are optional — call neither and the font scales
+within `[1.0, 1024.0]` pixels by default.
+
 ## Examples
 
 For complete examples, see [`examples/`](examples/) or run an example like this:
@@ -102,6 +124,7 @@ Other examples include:
 ```bash
 cargo run --example pick_list
 cargo run --example text_input
+cargo run --example fit_text
 ```
 
 ## Code Structure
@@ -112,14 +135,8 @@ The library is organized into modules for each enhanced widget:
   - `mouse_area.rs`: Sweetened mouse interaction handling
   - `pick_list.rs`: Sweetened pick list with item disabling
   - `text_input.rs`: Sweetened text input with focus handling
+  - `fit_text.rs`: Auto-scaling text that fits its bounds
   - (more widgets coming soon!)
-
-## Planned Features
-
-- [x] MouseArea widget
-- [x] PickList widget
-- [x] TextInput widget with focus management
-- [x] Row and Column with drag and drop
 
 ## Contributing
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `FitText` widget that auto-scales its font size to fit its laid-out
+  bounds. Think CSS `clamp(min, ideal, max)`, but with the "ideal" solved
+  for via binary search. Both `min_size` and `max_size` are optional —
+  unset, the font scales within `[1.0, 1024.0]` pixels by default. See
+  `examples/fit_text.rs` for a live demo.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 - [Text Input](#text-input)
 - [Mouse Area](#mouse-area)
 - [Pick List](#pick-list)
+- [Fit Text](#fit-text)
 
 Run any example using:
 
@@ -52,3 +53,15 @@ cargo run --example pick_list
 <div align="center">
   <img src="../assets/pick_list.gif" alt="Pick List Demo">
 </div>
+
+---
+
+## Fit Text
+
+Demonstrates the `fit_text` widget that auto-scales its font size to fit the
+available bounds. Type a headline and drag the min/max sliders to watch the
+binary-searched fit in action.
+
+```bash
+cargo run --example fit_text
+```

--- a/examples/fit_text.rs
+++ b/examples/fit_text.rs
@@ -1,0 +1,120 @@
+//! Demonstrates the [`FitText`] widget: a headline whose font size scales
+//! up and down to fit the bounds it is laid out into, while staying within
+//! a configurable `[min_size, max_size]` range.
+//!
+//! Type into the text field and resize the window to watch the headline
+//! scale to fit.
+//!
+//! Run with: `cargo run --example fit_text`
+//!
+//! [`FitText`]: sweeten::widget::fit_text::FitText
+
+use iced::widget::{center, column, container, row, slider, text};
+use iced::{Center, Element, Fill, Shrink};
+
+use sweeten::widget::{fit_text, text_input};
+
+fn main() -> iced::Result {
+    iced::application(App::default, App::update, App::view)
+        .title("sweeten • fit_text")
+        .theme(iced::Theme::Ferra)
+        .window_size((720.0, 420.0))
+        .run()
+}
+
+struct App {
+    headline: String,
+    max_size: f32,
+    min_size: f32,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            headline: "Headline that fits".to_string(),
+            max_size: 120.0,
+            min_size: 16.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Message {
+    EditHeadline(String),
+    SetMax(f32),
+    SetMin(f32),
+}
+
+impl App {
+    fn update(&mut self, message: Message) {
+        match message {
+            Message::EditHeadline(s) => self.headline = s,
+            Message::SetMax(size) => {
+                self.max_size = size;
+                if self.min_size > self.max_size {
+                    self.min_size = self.max_size;
+                }
+            }
+            Message::SetMin(size) => {
+                self.min_size = size;
+                if self.max_size < self.min_size {
+                    self.max_size = self.min_size;
+                }
+            }
+        }
+    }
+
+    fn view(&self) -> Element<'_, Message> {
+        let headline = fit_text(&self.headline)
+            .max_size(self.max_size)
+            .min_size(self.min_size)
+            .width(Fill)
+            .height(Fill)
+            .center();
+
+        let stage = container(headline)
+            .padding(12)
+            .width(Fill)
+            .height(Fill)
+            .clip(true)
+            .style(container::bordered_box);
+
+        let input = text_input("Type a headline...", &self.headline)
+            .on_input(Message::EditHeadline)
+            .size(18);
+
+        let max_row = row![
+            text("max").width(40.0),
+            slider(4.0..=240.0, self.max_size, Message::SetMax)
+                .step(1.0)
+                .width(Fill),
+            text(format!("{:>3.0}px", self.max_size)).width(56.0),
+        ]
+        .spacing(12)
+        .align_y(Center);
+
+        let min_row = row![
+            text("min").width(40.0),
+            slider(4.0..=240.0, self.min_size, Message::SetMin)
+                .step(1.0)
+                .width(Fill),
+            text(format!("{:>3.0}px", self.min_size)).width(56.0),
+        ]
+        .spacing(12)
+        .align_y(Center);
+
+        let controls = column![input, max_row, min_row]
+            .spacing(12)
+            .width(Fill)
+            .height(Shrink);
+
+        center(
+            column![stage, controls]
+                .spacing(16)
+                .width(Fill)
+                .height(Fill),
+        )
+        .padding(20)
+        .into()
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,6 +6,7 @@ use crate::overlay::menu;
 use crate::widget::MouseArea;
 use crate::widget::button::{self, Button};
 use crate::widget::column::{self, Column};
+use crate::widget::fit_text::{self, FitText};
 use crate::widget::pick_list::{self, PickList};
 use crate::widget::row::{self, Row};
 use crate::widget::text_input::{self, TextInput};
@@ -152,4 +153,19 @@ where
     Renderer: core::text::Renderer,
 {
     Toggler::new(is_toggled)
+}
+
+/// Creates a new [`FitText`] from the given content.
+///
+/// [`FitText`] scales its font size to fit the bounds it is laid out into,
+/// up to a configurable ceiling. See the [`fit_text`](crate::widget::fit_text)
+/// module docs for the semantics.
+pub fn fit_text<'a, Theme, Renderer>(
+    content: impl core::text::IntoFragment<'a>,
+) -> FitText<'a, Theme, Renderer>
+where
+    Theme: fit_text::Catalog,
+    Renderer: core::text::Renderer,
+{
+    FitText::new(content)
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -158,7 +158,7 @@ where
 /// Creates a new [`FitText`] from the given content.
 ///
 /// [`FitText`] scales its font size to fit the bounds it is laid out into,
-/// up to a configurable ceiling. See the [`fit_text`](crate::widget::fit_text)
+/// up to a configurable ceiling. See the [`fit_text`](mod@crate::widget::fit_text)
 /// module docs for the semantics.
 pub fn fit_text<'a, Theme, Renderer>(
     content: impl core::text::IntoFragment<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@
 //!   and [`on_blur`][button_on_blur] messages.
 //! - [`column`] — Distribute content vertically, with support for drag-and-drop
 //!   reordering via [`on_drag`](widget::column::Column::on_drag).
+//! - [`fit_text`] — A text widget that auto-scales its font size to fit the
+//!   available bounds, up to a configurable ceiling.
 //! - [`mouse_area`] — A container for capturing mouse events where all handlers
 //!   receive the cursor position as a [`Point`].
 //! - [`pick_list`] — A dropdown list of selectable options, with support for
@@ -63,6 +65,7 @@
 //! [`iced`]: https://github.com/iced-rs/iced
 //! [`button`]: mod@widget::button
 //! [`column`]: mod@widget::column
+//! [`fit_text`]: mod@widget::fit_text
 //! [`mouse_area`]: mod@widget::mouse_area
 //! [`pick_list`]: mod@widget::pick_list
 //! [`row`]: mod@widget::row

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -9,6 +9,7 @@
 pub mod button;
 pub mod column;
 pub mod drag;
+pub mod fit_text;
 pub mod mouse_area;
 pub mod operation;
 pub mod overlay;
@@ -19,6 +20,7 @@ pub mod toggler;
 
 pub use button::Button;
 pub use column::Column;
+pub use fit_text::FitText;
 pub use mouse_area::MouseArea;
 pub use pick_list::PickList;
 pub use row::Row;

--- a/src/widget/fit_text.rs
+++ b/src/widget/fit_text.rs
@@ -1,6 +1,6 @@
 //! Text that scales its font size to fit the bounds it is given.
 //!
-//! [`FitText`] is a drop-in-ish replacement for [`iced::widget::text`] where
+//! [`FitText`] is a drop-in-ish replacement for `iced::widget::text` where
 //! you hand it a range `[min_size, max_size]` and it picks the largest font
 //! size in that range whose shaped paragraph still fits inside the widget's
 //! laid-out bounds. Think CSS' `clamp(min, ideal, max)`, but the "ideal" is

--- a/src/widget/fit_text.rs
+++ b/src/widget/fit_text.rs
@@ -1,0 +1,520 @@
+//! Text that scales its font size to fit the bounds it is given.
+//!
+//! [`FitText`] is a drop-in-ish replacement for [`iced::widget::text`] where
+//! you hand it a range `[min_size, max_size]` and it picks the largest font
+//! size in that range whose shaped paragraph still fits inside the widget's
+//! laid-out bounds. Think CSS' `clamp(min, ideal, max)`, but the "ideal" is
+//! solved for instead of specified.
+//!
+//! # Example
+//! ```no_run
+//! # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; pub use iced_widget::core::Length::Fill; }
+//! # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
+//! use iced::Fill;
+//! use sweeten::widget::fit_text;
+//!
+//! enum Message {}
+//!
+//! fn view<'a>() -> Element<'a, Message> {
+//!     fit_text("BIG HEADLINE")
+//!         .max_size(120)
+//!         .min_size(16)
+//!         .width(Fill)
+//!         .height(96.0)
+//!         .center()
+//!         .into()
+//! }
+//! ```
+//!
+//! # How it works
+//!
+//! [`FitText`] binary-searches the size range using the renderer's
+//! [`Paragraph`] implementation. Each probe builds a throwaway paragraph
+//! at a candidate size and checks [`Paragraph::min_bounds`] against the
+//! fit bounds — so it's entirely in the widget layer, no renderer or
+//! `cosmic-text` changes required.
+//!
+//! Bounds follow the axis semantics of the widget's [`Length`] settings:
+//! a `Fill` or `Fixed` axis is fit-bounded, a `Shrink` axis is treated as
+//! unconstrained for fit purposes (since "shrink to content at max size"
+//! is the intuitive behavior there). So the canonical usage is one of:
+//!
+//! - `width(Fill)` + `wrapping(None)` — single-line fit that scales to
+//!   the available width
+//! - `width(Fill).height(Fill)` + `wrapping(Word)` — multi-line fit that
+//!   scales to both axes
+//!
+//! # Caveat
+//!
+//! With word wrapping, `fits(size)` is only approximately monotonic — a
+//! slightly larger font can reflow to fewer or more lines, flipping the
+//! predicate non-monotonically. Binary search still converges to a safe
+//! size (one that fits), but may pick a value a hair below the true
+//! optimum. In practice the error is imperceptible.
+
+use crate::core::alignment;
+use crate::core::layout::{self, Layout};
+use crate::core::mouse;
+use crate::core::renderer;
+use crate::core::text;
+use crate::core::text::paragraph::{self, Paragraph};
+use crate::core::widget::text as core_text;
+use crate::core::widget::tree::{self, Tree};
+use crate::core::{Color, Element, Length, Pixels, Rectangle, Size, Widget};
+
+pub use core_text::{
+    Alignment, Catalog, Ellipsis, LineHeight, Shaping, Style, StyleFn, Wrapping,
+};
+
+/// Text that scales its font size to fit its laid-out bounds.
+///
+/// See the [module docs](self) for details.
+#[must_use]
+pub struct FitText<'a, Theme = crate::Theme, Renderer = crate::Renderer>
+where
+    Theme: Catalog,
+    Renderer: text::Renderer,
+{
+    fragment: text::Fragment<'a>,
+    format: core_text::Format<Renderer::Font>,
+    min_size: Option<Pixels>,
+    max_size: Option<Pixels>,
+    class: Theme::Class<'a>,
+}
+
+/// Effective floor used when [`FitText::min_size`] is not set.
+const DEFAULT_MIN_SIZE: Pixels = Pixels(1.0);
+
+/// Effective cap used when [`FitText::max_size`] is not set.
+const DEFAULT_MAX_SIZE: Pixels = Pixels(1024.0);
+
+impl<'a, Theme, Renderer> FitText<'a, Theme, Renderer>
+where
+    Theme: Catalog,
+    Renderer: text::Renderer,
+{
+    /// Creates a new [`FitText`] from the given fragment.
+    ///
+    /// With no explicit [`min_size`](Self::min_size) or
+    /// [`max_size`](Self::max_size), the fit search is effectively
+    /// unbounded — the font scales within `[1.0, 1024.0]` pixels.
+    pub fn new(fragment: impl text::IntoFragment<'a>) -> Self {
+        let format = core_text::Format {
+            width: Length::Fill,
+            height: Length::Shrink,
+            wrapping: Wrapping::None,
+            ..core_text::Format::default()
+        };
+
+        FitText {
+            fragment: fragment.into_fragment(),
+            format,
+            min_size: None,
+            max_size: None,
+            class: Theme::default(),
+        }
+    }
+
+    /// Sets the maximum font size (the cap) used for the fit search.
+    ///
+    /// Defaults to `1024.0` pixels (effectively unbounded) if not set.
+    pub fn max_size(mut self, size: impl Into<Pixels>) -> Self {
+        self.max_size = Some(size.into());
+        self
+    }
+
+    /// Sets the minimum font size (the floor) used for the fit search.
+    ///
+    /// If the content doesn't fit even at `min_size`, the text is rendered
+    /// at `min_size` and may overflow — mirroring CSS' `clamp`.
+    ///
+    /// Defaults to `1.0` pixel if not set.
+    pub fn min_size(mut self, size: impl Into<Pixels>) -> Self {
+        self.min_size = Some(size.into());
+        self
+    }
+
+    /// Sets the [`LineHeight`] of the [`FitText`].
+    pub fn line_height(mut self, line_height: impl Into<LineHeight>) -> Self {
+        self.format.line_height = line_height.into();
+        self
+    }
+
+    /// Sets the [`Font`] of the [`FitText`].
+    ///
+    /// [`Font`]: text::Renderer::Font
+    pub fn font(mut self, font: impl Into<Renderer::Font>) -> Self {
+        self.format.font = Some(font.into());
+        self
+    }
+
+    /// Sets the [`Font`] of the [`FitText`], if `Some`.
+    ///
+    /// [`Font`]: text::Renderer::Font
+    pub fn font_maybe(
+        mut self,
+        font: Option<impl Into<Renderer::Font>>,
+    ) -> Self {
+        self.format.font = font.map(Into::into);
+        self
+    }
+
+    /// Sets the width of the [`FitText`] boundaries.
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.format.width = width.into();
+        self
+    }
+
+    /// Sets the height of the [`FitText`] boundaries.
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.format.height = height.into();
+        self
+    }
+
+    /// Centers the [`FitText`], both horizontally and vertically.
+    pub fn center(self) -> Self {
+        self.align_x(alignment::Horizontal::Center)
+            .align_y(alignment::Vertical::Center)
+    }
+
+    /// Sets the horizontal alignment of the [`FitText`].
+    pub fn align_x(mut self, alignment: impl Into<text::Alignment>) -> Self {
+        self.format.align_x = alignment.into();
+        self
+    }
+
+    /// Sets the vertical alignment of the [`FitText`].
+    pub fn align_y(
+        mut self,
+        alignment: impl Into<alignment::Vertical>,
+    ) -> Self {
+        self.format.align_y = alignment.into();
+        self
+    }
+
+    /// Sets the [`Shaping`] strategy of the [`FitText`].
+    pub fn shaping(mut self, shaping: Shaping) -> Self {
+        self.format.shaping = shaping;
+        self
+    }
+
+    /// Sets the [`Wrapping`] strategy of the [`FitText`].
+    pub fn wrapping(mut self, wrapping: Wrapping) -> Self {
+        self.format.wrapping = wrapping;
+        self
+    }
+
+    /// Sets the [`Ellipsis`] strategy of the [`FitText`].
+    pub fn ellipsis(mut self, ellipsis: Ellipsis) -> Self {
+        self.format.ellipsis = ellipsis;
+        self
+    }
+
+    /// Sets the style of the [`FitText`].
+    pub fn style(mut self, style: impl Fn(&Theme) -> Style + 'a) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        self.class = (Box::new(style) as StyleFn<'a, Theme>).into();
+        self
+    }
+
+    /// Sets the [`Color`] of the [`FitText`].
+    pub fn color(self, color: impl Into<Color>) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        self.color_maybe(Some(color))
+    }
+
+    /// Sets the [`Color`] of the [`FitText`], if `Some`.
+    pub fn color_maybe(self, color: Option<impl Into<Color>>) -> Self
+    where
+        Theme::Class<'a>: From<StyleFn<'a, Theme>>,
+    {
+        let color = color.map(Into::into);
+
+        self.style(move |_theme| Style { color })
+    }
+
+    /// Sets the style class of the [`FitText`].
+    #[cfg(feature = "advanced")]
+    pub fn class(mut self, class: impl Into<Theme::Class<'a>>) -> Self {
+        self.class = class.into();
+        self
+    }
+}
+
+/// The internal state of a [`FitText`] widget.
+///
+/// Holds the shaped paragraph alongside a cache of the last fit decision so
+/// we only re-run the search when an input actually changes.
+pub struct State<P: Paragraph> {
+    paragraph: paragraph::Plain<P>,
+    cache: Option<FitCache<P::Font>>,
+}
+
+impl<P: Paragraph> Default for State<P> {
+    fn default() -> Self {
+        Self {
+            paragraph: paragraph::Plain::default(),
+            cache: None,
+        }
+    }
+}
+
+/// Everything a fit result is a function of — if all of these match the
+/// last probe, we can reuse the previously chosen size.
+#[derive(Clone)]
+struct FitCache<Font> {
+    content: String,
+    fit_bounds: Size,
+    font: Font,
+    line_height: LineHeight,
+    shaping: Shaping,
+    wrapping: Wrapping,
+    ellipsis: Ellipsis,
+    hint_factor: Option<f32>,
+    min_size: Pixels,
+    max_size: Pixels,
+    chosen: Pixels,
+}
+
+impl<Font: PartialEq> FitCache<Font> {
+    fn matches(&self, probe: &FitCache<Font>) -> bool {
+        self.content == probe.content
+            && size_eq(self.fit_bounds, probe.fit_bounds)
+            && self.font == probe.font
+            && self.line_height == probe.line_height
+            && self.shaping == probe.shaping
+            && self.wrapping == probe.wrapping
+            && self.ellipsis == probe.ellipsis
+            && self.hint_factor == probe.hint_factor
+            && self.min_size == probe.min_size
+            && self.max_size == probe.max_size
+    }
+}
+
+fn size_eq(a: Size, b: Size) -> bool {
+    a.width.to_bits() == b.width.to_bits()
+        && a.height.to_bits() == b.height.to_bits()
+}
+
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for FitText<'_, Theme, Renderer>
+where
+    Theme: Catalog,
+    Renderer: text::Renderer,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State<Renderer::Paragraph>>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::<Renderer::Paragraph>::default())
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: self.format.width,
+            height: self.format.height,
+        }
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
+
+        layout::sized(limits, self.format.width, self.format.height, |limits| {
+            let bounds = limits.max();
+            let compression = limits.compression();
+
+            // A Shrink axis has no meaningful "fit bound"; leave it
+            // unconstrained so the text can grow to max_size there.
+            let fit_bounds = Size::new(
+                if compression.width {
+                    f32::INFINITY
+                } else {
+                    bounds.width
+                },
+                if compression.height {
+                    f32::INFINITY
+                } else {
+                    bounds.height
+                },
+            );
+
+            let font =
+                self.format.font.unwrap_or_else(|| renderer.default_font());
+            let hint_factor = renderer.scale_factor();
+
+            let min = self.min_size.unwrap_or(DEFAULT_MIN_SIZE);
+            let max = self.max_size.unwrap_or(DEFAULT_MAX_SIZE);
+
+            // Clamp so min <= max even if the user passed them backwards.
+            let min_size = Pixels(min.0.min(max.0));
+            let max_size = Pixels(min.0.max(max.0));
+
+            let probe_key = FitCache {
+                content: self.fragment.to_string(),
+                fit_bounds,
+                font,
+                line_height: self.format.line_height,
+                shaping: self.format.shaping,
+                wrapping: self.format.wrapping,
+                ellipsis: self.format.ellipsis,
+                hint_factor,
+                min_size,
+                max_size,
+                chosen: Pixels::ZERO, // filled in below
+            };
+
+            let chosen = match &state.cache {
+                Some(cached) if cached.matches(&probe_key) => cached.chosen,
+                _ => {
+                    let chosen = fit::<Renderer::Paragraph>(
+                        &self.fragment,
+                        fit_bounds,
+                        font,
+                        min_size,
+                        max_size,
+                        &self.format,
+                        hint_factor,
+                    );
+                    state.cache = Some(FitCache {
+                        chosen,
+                        ..probe_key
+                    });
+                    chosen
+                }
+            };
+
+            // Commit the chosen size into the cached paragraph.
+            let _ = state.paragraph.update(text::Text {
+                content: &self.fragment,
+                bounds,
+                size: chosen,
+                line_height: self.format.line_height,
+                font,
+                align_x: self.format.align_x,
+                align_y: self.format.align_y,
+                shaping: self.format.shaping,
+                wrapping: self.format.wrapping,
+                ellipsis: self.format.ellipsis,
+                hint_factor,
+            });
+
+            state.paragraph.min_bounds()
+        })
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        defaults: &renderer::Style,
+        layout: Layout<'_>,
+        _cursor_position: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<State<Renderer::Paragraph>>();
+        let style = theme.style(&self.class);
+
+        core_text::draw(
+            renderer,
+            defaults,
+            layout.bounds(),
+            state.paragraph.raw(),
+            style,
+            viewport,
+        );
+    }
+
+    fn operate(
+        &mut self,
+        _tree: &mut Tree,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        operation: &mut dyn crate::core::widget::Operation,
+    ) {
+        operation.text(None, layout.bounds(), &self.fragment);
+    }
+}
+
+/// Binary-searches `[min_size, max_size]` for the largest font size whose
+/// shaped paragraph fits inside `fit_bounds`.
+fn fit<P: Paragraph>(
+    content: &str,
+    fit_bounds: Size,
+    font: P::Font,
+    min_size: Pixels,
+    max_size: Pixels,
+    format: &core_text::Format<P::Font>,
+    hint_factor: Option<f32>,
+) -> Pixels {
+    // Slight tolerance so 0.4px overrun doesn't reject an otherwise-fine
+    // size — cosmic-text's measurements vary sub-pixel between probes.
+    let tol = 0.5;
+
+    let probe = |size: Pixels| -> Size {
+        let p = P::with_text(text::Text {
+            content,
+            bounds: fit_bounds,
+            size,
+            line_height: format.line_height,
+            font,
+            align_x: format.align_x,
+            align_y: format.align_y,
+            shaping: format.shaping,
+            wrapping: format.wrapping,
+            ellipsis: format.ellipsis,
+            hint_factor,
+        });
+        p.min_bounds()
+    };
+
+    let fits = |mb: Size| -> bool {
+        mb.width <= fit_bounds.width + tol
+            && mb.height <= fit_bounds.height + tol
+    };
+
+    // Fast path: if the ceiling already fits, we're done.
+    if fits(probe(max_size)) {
+        return max_size;
+    }
+    // Floor path: if even the floor doesn't fit, bottom out at it.
+    if !fits(probe(min_size)) {
+        return min_size;
+    }
+
+    // Binary search to ~0.5px precision.
+    let mut lo = min_size.0;
+    let mut hi = max_size.0;
+    while hi - lo > 0.5 {
+        let mid = (lo + hi) * 0.5;
+        if fits(probe(Pixels(mid))) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Pixels(lo)
+}
+
+impl<'a, Message, Theme, Renderer> From<FitText<'a, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Theme: Catalog + 'a,
+    Renderer: text::Renderer + 'a,
+{
+    fn from(
+        text: FitText<'a, Theme, Renderer>,
+    ) -> Element<'a, Message, Theme, Renderer> {
+        Element::new(text)
+    }
+}


### PR DESCRIPTION
## Summary

- New `FitText` widget: text that auto-scales its font size to fit the bounds it is laid out into. Think CSS' `clamp(min, ideal, max)` with the "ideal" solved for via binary search against the renderer's `Paragraph` measurements — no renderer or `cosmic-text` changes required.
- Both `min_size` and `max_size` are optional. Unset, the font scales within `[1.0, 1024.0]` pixels; setting either or both narrows the range.
- Internal cache keyed on inputs (content, bounds, font, line height, shaping, wrapping, ellipsis, min/max) so the binary search only re-runs when something actually changes.
- New `examples/fit_text.rs` showing a headline that scales as you type and drag the min/max sliders.
- Documents the widget in `README.md` and `examples/README.md`, and introduces `docs/CHANGELOG.md`.

## Notes

- This PR was originally cherry-picked from `dev` onto `master` directly; it's being reintroduced as a proper PR now. The commits here match what was briefly on `master` plus the docs/CHANGELOG follow-up.
- Typography extras from the `dev` branch (`weight`, `letter_spacing`, `font_feature(s)`, `font_variation(s)`) are intentionally stripped here because upstream `iced-rs/iced:master` doesn't expose those fields yet.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test` (fit_text doctest passes; pre-existing `pick_list` doctest failure on master is unrelated)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo doc --no-deps` clean (no broken intra-doc links)
- [x] `cargo run --example fit_text` renders correctly and scales as expected