### PR TITLE
feat(toggler): crossfade fill colors during animation; document Button & Toggler

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ sweeten = { git = "https://github.com/airstrike/sweeten", branch = "master" }
 
 ## Current Features
 
+### `Button`
+
+A sweetened version of `iced`'s `button` widget with focus-related callbacks:
+
+- `.on_focus(Message)` fires when the button gains keyboard focus
+- `.on_blur(Message)` fires when it loses focus
+
+Pairs with `sweeten::widget::operation::{focus_next, focus_previous}` to build
+keyboard-navigable forms where any kind of widget can be focused.
+
+### `Toggler`
+
+A sweetened version of `iced`'s `toggler` widget that smoothly animates state
+changes — the handle slides between positions and the fill color crossfades
+between the off- and on-state styles.
+
+```rust
+toggler(self.is_on)
+    .label("Enable notifications")
+    .on_toggle(Message::Toggled)
+```
+
 ### `MouseArea`
 
 A sweetened version of `iced`'s `mouse_area` widget with an additional
@@ -132,6 +154,8 @@ cargo run --example fit_text
 The library is organized into modules for each enhanced widget:
 
 - `widget/`: Contains all widget implementations
+  - `button.rs`: Sweetened button with focus/blur callbacks
+  - `toggler.rs`: Sweetened toggler with animated state changes
   - `mouse_area.rs`: Sweetened mouse interaction handling
   - `pick_list.rs`: Sweetened pick list with item disabling
   - `text_input.rs`: Sweetened text input with focus handling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,16 +1,13 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
+- `FitText` widget that auto-scales font size to fit its bounds via binary search. [#13](https://github.com/airstrike/sweeten/pull/13)
+- README sections for `Button` and `Toggler`.
 
-- `FitText` widget that auto-scales its font size to fit its laid-out
-  bounds. Think CSS `clamp(min, ideal, max)`, but with the "ideal" solved
-  for via binary search. Both `min_size` and `max_size` are optional —
-  unset, the font scales within `[1.0, 1024.0]` pixels by default. See
-  `examples/fit_text.rs` for a live demo.
+### Changed
+- Crossfade `Toggler` fill colors during toggle animation instead of snapping.

--- a/src/widget/toggler.rs
+++ b/src/widget/toggler.rs
@@ -456,12 +456,52 @@ where
         let mut children = layout.children();
         let toggler_layout = children.next().unwrap();
 
-        let style = theme.style(
-            &self.class,
-            self.last_status.unwrap_or(Status::Disabled {
-                is_toggled: self.is_toggled,
-            }),
-        );
+        let current_status = self.last_status.unwrap_or(Status::Disabled {
+            is_toggled: self.is_toggled,
+        });
+
+        // While the toggle is animating, interpolate the fill colors between
+        // the off- and on-state styles so the background/foreground fade in
+        // sync with the handle slide, not snap instantly when `is_toggled`
+        // flips.
+        let style = match state.now {
+            Some(now) if state.animation.is_animating(now) => {
+                let off = theme
+                    .style(&self.class, current_status.with_toggled(false));
+                let on =
+                    theme.style(&self.class, current_status.with_toggled(true));
+
+                // Only `Background::Color` is interpolable here; fall back to
+                // transparent for gradients so the draw code stays simple.
+                let bg_color = |bg: Background| match bg {
+                    Background::Color(c) => c,
+                    _ => Color::TRANSPARENT,
+                };
+
+                let background =
+                    Background::Color(state.animation.interpolate(
+                        bg_color(off.background),
+                        bg_color(on.background),
+                        now,
+                    ));
+                let foreground =
+                    Background::Color(state.animation.interpolate(
+                        bg_color(off.foreground),
+                        bg_color(on.foreground),
+                        now,
+                    ));
+
+                // Snap non-color fields to the animation's current target —
+                // interpolating border widths/radius/padding shimmers.
+                let target = if state.animation.value() { on } else { off };
+                Style {
+                    background,
+                    foreground,
+                    ..target
+                }
+            }
+            _ => theme.style(&self.class, current_status),
+        };
 
         if self.label.is_some() {
             let label_layout = children.next().unwrap();
@@ -577,6 +617,17 @@ pub enum Status {
         /// Indicates whether the [`Toggler`] is toggled.
         is_toggled: bool,
     },
+}
+
+impl Status {
+    /// Returns this [`Status`] with its `is_toggled` field replaced.
+    fn with_toggled(self, is_toggled: bool) -> Self {
+        match self {
+            Status::Active { .. } => Status::Active { is_toggled },
+            Status::Hovered { .. } => Status::Hovered { is_toggled },
+            Status::Disabled { .. } => Status::Disabled { is_toggled },
+        }
+    }
 }
 
 /// The appearance of a toggler.


### PR DESCRIPTION
## Summary

- **Fix**: `Toggler`'s background and foreground fill colors now crossfade between the off- and on-state styles during the toggle animation, in sync with the handle slide. Previously the colors snapped the moment `is_toggled` flipped. Non-color fields (border width, border radius, padding) still snap to the target to avoid sub-pixel shimmer.
- **Docs**: adds README sections for `Button` and `Toggler` (both were implemented on master but not documented), and lists them under Code Structure.
- **Changelog**: updated under `## [Unreleased]`, restyled to match `iced`'s changelog convention (one-line punchy entries with PR links).

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --doc toggler` passes
- [x] `cargo test --doc fit_text` passes (sanity)
- [ ] Visual check: toggle a `Toggler` and confirm the fill crossfades smoothly instead of snapping